### PR TITLE
Generic server has no mgmt nic

### DIFF
--- a/src/infragraph/server.py
+++ b/src/infragraph/server.py
@@ -46,10 +46,20 @@ class Server(Device):
             count=npu_factor * 2,
         )
         nic.choice = Component.NIC
+        mgmt = self.components.add(
+            name="mgmt",
+            description="Mgmt Nic",
+            count=1,
+        )
+        mgmt.choice = Component.NIC
 
         cpu_fabric = self.links.add(name="fabric", description="CPU Fabric")
         nvlink = self.links.add(name="nvlink")
         pcie = self.links.add(name="pcie")
+
+        edge = self.edges.add(scheme=DeviceEdge.ONE2ONE, link=pcie.name)
+        edge.ep1.component = mgmt.name
+        edge.ep2.component = f"{cpu.name}[0]"
 
         edge = self.edges.add(scheme=DeviceEdge.MANY2MANY, link=cpu_fabric.name)
         edge.ep1.component = cpu.name

--- a/src/tests/test_ipaddress_annotations.py
+++ b/src/tests/test_ipaddress_annotations.py
@@ -18,7 +18,7 @@ async def test_ipaddress_annotations():
     filter = npu_request.node_filters.add(name="nic filter")
     filter.choice = QueryNodeFilter.ID_FILTER
     filter.id_filter.operator = QueryNodeId.REGEX
-    filter.id_filter.value = r"host\.\d+\.nic\.\d+"
+    filter.id_filter.value = r"host\.\d+\.mgmt\.\d+"
     nic_response = service.query_graph(npu_request)
 
     # annotate the graph


### PR DESCRIPTION
Issue: 
- There is no sample of how to add a management ipaddress to each server

Expected Behavior:
- a mgmt nic should be part of the generic server components
- the ipaddress annotation test should demonstrate how to add a mgmt ip address to a generic server
- the documentation should reflect the test 
