### PR TITLE
Add project URLs for homepage and repository in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,10 @@ classifiers = [
 ]
 dynamic = ["version"]
 
+[project.urls]
+"Homepage" = "https://infragraph.dev/"
+"Repository" = "https://github.com/Keysight/infragraph"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Issue
- missing homepage and repository urls in the infragraph python package

## Resolution 
- update pyproject.toml with doc url as homepage and repository url

## Testing
- manual verification in wheel metadata file of urls 